### PR TITLE
Fixed array creation bug on Nashorn

### DIFF
--- a/jsface.js
+++ b/jsface.js
@@ -122,7 +122,7 @@
     bindTo = singleton ? clazz : clazz.prototype;
 
     // make sure parent is always an array
-    parent = !parent || arrayOrNil(parent) ? parent : [ parent ];
+    parent = !parent || arrayOrNil(parent) ? parent : new Array( parent );
 
     // do inherit
     len = parent && parent.length;


### PR DESCRIPTION
Nashorn doesn't like the way the parent variable is coerced to an array. Fixed by calling the Array constructor.