### PR TITLE
Update jsDelivr link

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ bower install jsface
 #### dnsjs
 
 ``` javascript
-<script src="https://cdn.jsdelivr.net/jsface/2.4.9/jsface.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/jsface@2.4.9/dist/jsface.min.js"></script>
 ```
 
 #### Manually


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the link now so you don't forget to do it when you release a new version.

You can find links for all files at https://www.jsdelivr.com/package/npm/jsface.

Feel free to ping me if you have any questions regarding this change.